### PR TITLE
Upgraded to elmah.io 2

### DIFF
--- a/src/Serilog.Sinks.ElmahIO/LoggerConfigurationElmahIOExtensions.cs
+++ b/src/Serilog.Sinks.ElmahIO/LoggerConfigurationElmahIOExtensions.cs
@@ -36,7 +36,7 @@ namespace Serilog
         public static LoggerConfiguration ElmahIO(
             this LoggerSinkConfiguration loggerConfiguration,
              Guid logId,
-            LogEventLevel restrictedToMinimumLevel = LogEventLevel.Error,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
@@ -41,8 +41,9 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah.Io.Client">
-      <HintPath>..\..\packages\elmah.io.client.2.0.18-beta\lib\net40\Elmah.Io.Client.dll</HintPath>
+    <Reference Include="Elmah.Io.Client, Version=2.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\elmah.io.client.2.0.20\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
@@ -41,12 +41,8 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah">
-      <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
-    </Reference>
-    <Reference Include="Elmah.Io, Version=1.0.0.30, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\elmah.io.core.1.0.0.38\lib\net40\Elmah.Io.dll</HintPath>
+    <Reference Include="Elmah.Io.Client">
+      <HintPath>..\..\packages\elmah.io.client.2.0.18-beta\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
@@ -41,9 +41,9 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah.Io.Client, Version=2.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Elmah.Io.Client, Version=2.0.21.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\elmah.io.client.2.0.20\lib\net40\Elmah.Io.Client.dll</HintPath>
+      <HintPath>..\..\packages\elmah.io.client.2.0.21\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -66,7 +66,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="Serilog.Sinks.ElmahIO.nuspec" />
+    <None Include="Serilog.Sinks.ElmahIO.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -12,7 +12,7 @@
     <tags>serilog logging elmah elmah.io error</tags>
     <dependencies>
       <dependency id="Serilog" version="$version$" />
-      <dependency id="elmah.io.client" version="2.0.20" />
+      <dependency id="elmah.io.client" version="2.0.21" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -12,7 +12,7 @@
     <tags>serilog logging elmah elmah.io error</tags>
     <dependencies>
       <dependency id="Serilog" version="$version$" />
-      <dependency id="elmah.io.client" version="2.0.18-beta" />
+      <dependency id="elmah.io.client" version="2.0.20" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -3,8 +3,8 @@
   <metadata>
     <id>Serilog.Sinks.ElmahIO</id>
     <version>$version$</version>
-    <authors>Michiel van Oudheusden</authors>
-    <description>Serilog event sink that writes to the Elmah.io service.</description>
+    <authors>Michiel van Oudheusden,elmah.io</authors>
+    <description>Serilog event sink that writes to the elmah.io service.</description>
     <language>en-US</language>
     <projectUrl>http://serilog.net</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -12,8 +12,7 @@
     <tags>serilog logging elmah elmah.io error</tags>
     <dependencies>
       <dependency id="Serilog" version="$version$" />
-      <dependency id="elmah.corelibrary" version="1.2.2" />
-      <dependency id="elmah.io.core" version="1.0.0.40" />
+      <dependency id="elmah.io.client" version="2.0.18-beta" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
+++ b/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
@@ -47,7 +47,7 @@ namespace Serilog.Sinks.ElmahIO
             var message = new Message(logEvent.RenderMessage(_formatProvider))
             {
                 Severity = LevelToSeverity(logEvent),
-                DateTime = logEvent.Timestamp.DateTime,
+                DateTime = logEvent.Timestamp.DateTime.ToUniversalTime(),
                 Detail = logEvent.Exception != null ? logEvent.Exception.ToString() : null
             };
 

--- a/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
+++ b/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 using System;
-using Elmah;
+using Elmah.Io.Client;
 using Serilog.Core;
 using Serilog.Events;
-using ErrorLog = Elmah.Io.ErrorLog;
 
 namespace Serilog.Sinks.ElmahIO
 {
@@ -26,7 +25,7 @@ namespace Serilog.Sinks.ElmahIO
     public class ElmahIOSink : ILogEventSink
     {
         readonly IFormatProvider _formatProvider;
-        readonly ErrorLog _errorLog;
+        readonly Logger _logger;
 
         /// <summary>
         /// Construct a sink that saves logs to the specified storage account.
@@ -36,7 +35,7 @@ namespace Serilog.Sinks.ElmahIO
         public ElmahIOSink(IFormatProvider formatProvider, Guid logId)
         {
             _formatProvider = formatProvider;
-            _errorLog = new ErrorLog(logId);
+            _logger = new Logger(logId);
         }
 
         /// <summary>
@@ -45,12 +44,33 @@ namespace Serilog.Sinks.ElmahIO
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            var error = logEvent.Exception != null ? new Error(logEvent.Exception) : new Error();
+            var message = new Message(logEvent.RenderMessage(_formatProvider))
+            {
+                Severity = LevelToSeverity(logEvent),
+                DateTime = logEvent.Timestamp.DateTime,
+                Detail = logEvent.Exception != null ? logEvent.Exception.ToString() : null
+            };
 
-            error.Message = logEvent.RenderMessage(_formatProvider);
-            error.Time = logEvent.Timestamp.DateTime;
+            _logger.Log(message);
+        }
 
-            _errorLog.Log(error);
+        static Severity LevelToSeverity(LogEvent logEvent)
+        {
+            switch (logEvent.Level)
+            {
+                case LogEventLevel.Debug:
+                    return Severity.Debug;
+                case LogEventLevel.Error:
+                    return Severity.Error;
+                case LogEventLevel.Fatal:
+                    return Severity.Fatal;
+                case LogEventLevel.Verbose:
+                    return Severity.Verbose;
+                case LogEventLevel.Warning:
+                    return Severity.Warning;
+                default:
+                    return Severity.Information;
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.ElmahIO/packages.config
+++ b/src/Serilog.Sinks.ElmahIO/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.io.client" version="2.0.20" targetFramework="net45" />
+  <package id="elmah.io.client" version="2.0.21" targetFramework="net45" />
   <package id="Serilog" version="1.4.204" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.ElmahIO/packages.config
+++ b/src/Serilog.Sinks.ElmahIO/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.io.client" version="2.0.18-beta" targetFramework="net45" />
+  <package id="elmah.io.client" version="2.0.20" targetFramework="net45" />
   <package id="Serilog" version="1.4.204" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.ElmahIO/packages.config
+++ b/src/Serilog.Sinks.ElmahIO/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
-  <package id="elmah.io.core" version="1.0.0.38" targetFramework="net45" />
+  <package id="elmah.io.client" version="2.0.18-beta" targetFramework="net45" />
   <package id="Serilog" version="1.4.204" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The new elmah.io v2 API plus it's .NET client, offers some new possibilities compared to v1. You no longer need to reference neither ELMAH nor the ErrorLog implementation. The Logger API supports logging events from logging frameworks like Serilog and now also supports severities.