### PR TITLE
Handle Serilog properties and upgraded to newest elmah.io client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,1 @@
-# Serilog.Sinks.Elmahio
-
-[![Build status](https://ci.appveyor.com/api/projects/status/j4rsru1m0lhkfwc4/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-elmahio/branch/master)
-
-A Serilog sink that writes events to elmah.io. [Elmah.io](http://www.elmah.io] is a cloud hosted solution to capture errors. Register for an account at their website and use the provided GUID in the configuration for serilog.
-
-**Package** - [Serilog.Sinks.ElmahIO](http://nuget.org/packages/serilog.sinks.ElmahIO]
-| **Platforms** - .NET 4.5
-
-```csharp
-var log = new LoggerConfiguration()
-    .WriteTo.ElmahIO(new Guid("{your guid}"))
-    .CreateLogger();
-```
-
-As elmah.io is primarily used for error tracking, the default level is set to `Error`. You can override this, but not all the data on the site is filled in as not all the Serilog properties can be matched. 
+# Serilog.Sinks.Elmahio[![Build status](https://ci.appveyor.com/api/projects/status/j4rsru1m0lhkfwc4/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-elmahio/branch/master)A Serilog sink that writes events to elmah.io. [elmah.io](http://www.elmah.io) is a cloud hosted solution to capture log messages. Register for an account at their website and use the provided GUID in the configuration for Serilog.**Package** - [Serilog.Sinks.ElmahIO](http://nuget.org/packages/serilog.sinks.ElmahIO)| **Platforms** - .NET 4.5```csharpvar log = new LoggerConfiguration()    .WriteTo.ElmahIO(new Guid("{your guid}"))    .CreateLogger();```The sink captures all levels, but respect the minimum level configured on LoggerConfiguration. Serilog properties are converted to elmah.io's concept of custom variables, when logging new events.

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.csproj
@@ -41,9 +41,9 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah.Io.Client, Version=2.0.21.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Elmah.Io.Client, Version=2.0.22.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\elmah.io.client.2.0.21\lib\net40\Elmah.Io.Client.dll</HintPath>
+      <HintPath>..\..\packages\elmah.io.client.2.0.22\lib\net40\Elmah.Io.Client.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
+++ b/src/Serilog.Sinks.ElmahIO/Serilog.Sinks.ElmahIO.nuspec
@@ -12,7 +12,7 @@
     <tags>serilog logging elmah elmah.io error</tags>
     <dependencies>
       <dependency id="Serilog" version="$version$" />
-      <dependency id="elmah.io.client" version="2.0.21" />
+      <dependency id="elmah.io.client" version="2.0.22" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.ElmahIO/packages.config
+++ b/src/Serilog.Sinks.ElmahIO/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.io.client" version="2.0.21" targetFramework="net45" />
+  <package id="elmah.io.client" version="2.0.22" targetFramework="net45" />
   <package id="Serilog" version="1.4.204" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The sink now extracts content from the logged exceptions Data dictionary (if any exception) and send that as custom variables to elmah.io. Also all properties logged through Serilog are converted to custom variables.

Upgraded to newest elmah.io.client, containing a bugfix with json serialization of message severities.