### PR TITLE
Set Type, Hostname and User fields on all messages

### DIFF
--- a/src/Serilog.Sinks.ElmahIO.Test/Sinks/ElmahIO/ElmahIOSinkTest.cs
+++ b/src/Serilog.Sinks.ElmahIO.Test/Sinks/ElmahIO/ElmahIOSinkTest.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.ElmahIO.Test.Sinks.ElmahIO
                     loggedMessage = msg;
                 });
             var now = DateTimeOffset.Now;
-            var applicationException = new ApplicationException();
+            var exception = Exception();
             var principalMock = new Mock<IPrincipal>();
             var identityMock = new Mock<IIdentity>();
             identityMock.Setup(x => x.Name).Returns("User");
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.ElmahIO.Test.Sinks.ElmahIO
                 new LogEvent(
                     now,
                     LogEventLevel.Error,
-                    applicationException,
+                    exception,
                     new MessageTemplate("Simple test", new List<MessageTemplateToken>()), new List<LogEventProperty>
                     {
                         new LogEventProperty("name", new ScalarValue("value"))
@@ -51,13 +51,18 @@ namespace Serilog.Sinks.ElmahIO.Test.Sinks.ElmahIO
             Assert.That(loggedMessage != null);
             Assert.That(loggedMessage.Severity, Is.EqualTo(Severity.Error));
             Assert.That(loggedMessage.DateTime, Is.EqualTo(now.DateTime.ToUniversalTime()));
-            Assert.That(loggedMessage.Detail, Is.EqualTo(applicationException.ToString()));
+            Assert.That(loggedMessage.Detail, Is.EqualTo(exception.ToString()));
             Assert.That(loggedMessage.Data != null);
             Assert.That(loggedMessage.Data.Count, Is.EqualTo(1));
             Assert.That(loggedMessage.Data.First().Key, Is.EqualTo("name"));
-            Assert.That(loggedMessage.Type, Is.EqualTo(applicationException.GetType().FullName));
+            Assert.That(loggedMessage.Type, Is.EqualTo(typeof(DivideByZeroException).FullName));
             Assert.That(loggedMessage.Hostname, Is.EqualTo(Environment.MachineName));
             Assert.That(loggedMessage.User, Is.EqualTo("User"));
+        }
+
+        private Exception Exception()
+        {
+            return new ApplicationException("error", new DivideByZeroException());
         }
     }
 }

--- a/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
+++ b/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
@@ -82,7 +82,7 @@ namespace Serilog.Sinks.ElmahIO
 
         private string Type(LogEvent logEvent)
         {
-            return logEvent.Exception == null ? null : logEvent.Exception.GetType().FullName;
+            return logEvent.Exception?.GetBaseException().GetType().FullName;
         }
 
         static List<Item> PropertiesToData(LogEvent logEvent)

--- a/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
+++ b/src/Serilog.Sinks.ElmahIO/Sinks/ElmahIO/ElmahIOSink.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Elmah.Io.Client;
 using Serilog.Core;
 using Serilog.Events;
@@ -64,9 +65,24 @@ namespace Serilog.Sinks.ElmahIO
                 DateTime = logEvent.Timestamp.DateTime.ToUniversalTime(),
                 Detail = logEvent.Exception != null ? logEvent.Exception.ToString() : null,
                 Data = PropertiesToData(logEvent),
+                Type = Type(logEvent),
+                Hostname = Environment.MachineName,
+                User = User(),
             };
 
             _logger.Log(message);
+        }
+
+        private string User()
+        {
+            if (Thread.CurrentPrincipal == null || Thread.CurrentPrincipal.Identity == null) return null;
+
+            return Thread.CurrentPrincipal.Identity.Name;
+        }
+
+        private string Type(LogEvent logEvent)
+        {
+            return logEvent.Exception == null ? null : logEvent.Exception.GetType().FullName;
         }
 
         static List<Item> PropertiesToData(LogEvent logEvent)


### PR DESCRIPTION
Three additional properties on the message send to elmah.io can be set automatically.